### PR TITLE
feat: Implement asset assignment and de-assignment by direct tag input

### DIFF
--- a/userCheckIO/forms.py
+++ b/userCheckIO/forms.py
@@ -42,28 +42,18 @@ class CategoryFilterForm(forms.Form):
         # If not, it will retain the default [('', 'All Categories')]
 
 class AssignAssetForm(forms.Form):
-    asset_id = forms.ChoiceField(
-        label="Select Asset to Assign", 
-        required=True, 
-        choices=[] # Initial empty choices, to be populated by the view
+    asset_tag = forms.CharField(
+        label="Asset Tag",
+        required=True,
+        max_length=100, # Assuming a reasonable max length for asset tags
+        widget=forms.TextInput(attrs={'class': 'input'}) # Basic styling
     )
 
-    def __init__(self, *args, **kwargs):
-        assets_choices = kwargs.pop('assets_choices', [])
-        super().__init__(*args, **kwargs)
-        if assets_choices:
-            # Ensure a default, non-selectable first option if choices are available
-            self.fields['asset_id'].choices = [('', '-- Select an Asset --')] + assets_choices
-            self.fields['asset_id'].widget.attrs.pop('disabled', None) # Ensure not disabled
-        else:
-            # If no assets are available, show a message and disable the field
-            self.fields['asset_id'].choices = [('', 'No available assets found or error fetching assets')]
-            self.fields['asset_id'].widget.attrs['disabled'] = True
-        
-        # Ensure required=True makes sense with potentially disabled field
-        # If disabled and no assets, it shouldn't fail form validation if submitted (though button should be disabled too)
-        # For now, the view logic should prevent submission if no assets.
-        # If the field is disabled, its value won't be submitted anyway.
-        # `required=True` is more for when the field is active and has options.
-        if not assets_choices:
-            self.fields['asset_id'].required = False # Don't require if disabled and no choices
+class UnassignAssetForm(forms.Form):
+    asset_tag = forms.CharField(
+        label=_("Asset Tag to Unassign"), # Using gettext_lazy for potential translation
+        max_length=100,
+        required=True,
+        widget=forms.TextInput(attrs={'class': 'input',
+                                      'placeholder': _('Enter asset tag to unassign')})
+    )

--- a/userCheckIO/templates/asset_list.html
+++ b/userCheckIO/templates/asset_list.html
@@ -33,8 +33,10 @@
                         Category: {{ asset.category.name|default:"N/A" }}
                     </div>
                     <div class="asset-actions">
-                        {% if asset.id %}
-                        <a href="{% url 'unassign_asset' asset_id=asset.id %}" class="unassign-btn">Unassign</a>
+                        {# The user.id is from the user whose asset list is being viewed #}
+                        {# This link now goes to a page where an asset tag can be entered for unassignment #}
+                        {% if user.id %} {# Ensures we have a user context to pass #}
+                        <a href="{% url 'unassign_asset_by_tag' user_id=user.id %}" class="unassign-btn">Unassign by Tag</a>
                         {% endif %}
                     </div>
                 </li>

--- a/userCheckIO/templates/assign_asset.html
+++ b/userCheckIO/templates/assign_asset.html
@@ -20,16 +20,32 @@
 
     <form method="post" action="{% url 'assign_asset' user_id=user_id %}">
         {% csrf_token %}
-        <label for="asset_id">Select Asset to Assign:</label>
-        <select name="asset_id" id="asset_id" required>
-            <option value="">-- Select an Asset --</option>
-            {% for asset in available_assets %}
-                <option value="{{ asset.id }}">{{ asset.name }} - Model: {{ asset.model.name }}</option>
-            {% empty %}
-                <option value="" disabled>No available assets found or error fetching assets.</option>
+        {# Display non_field_errors if any (e.g., from messages framework if form itself doesn't handle them) #}
+        {% if form.non_field_errors %}
+            <div class="notification is-danger">
+                {% for error in form.non_field_errors %}
+                    <p>{{ error }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        {# Render the asset_tag field using Django's form rendering #}
+        {# This will include the label, input, and any validation errors for the field #}
+        <div class="field">
+            <label for="{{ form.asset_tag.id_for_label }}" class="label">{{ form.asset_tag.label }}</label>
+            <div class="control">
+                {# Add/ensure 'input' class for Bulma styling, and a placeholder #}
+                {{ form.asset_tag.as_widget(attrs={'class': 'input', 'placeholder': 'Enter asset tag'}) }}
+            </div>
+            {% if form.asset_tag.help_text %}
+                <p class="help">{{ form.asset_tag.help_text }}</p>
+            {% endif %}
+            {% for error in form.asset_tag.errors %}
+                <p class="help is-danger">{{ error }}</p>
             {% endfor %}
-        </select>
-        <button type="submit" {% if not available_assets %}disabled{% endif %}>Assign Selected Asset</button>
+        </div>
+
+        <button type="submit" class="button is-primary">Assign Asset by Tag</button>
     </form>
 
     <hr>

--- a/userCheckIO/templates/unassign_asset_by_tag.html
+++ b/userCheckIO/templates/unassign_asset_by_tag.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+
+{% block title %}Unassign Asset from {{ user_context.name|default:user_context.username|default_if_none:"User" }}{% endblock %}
+
+{% block content %}
+    <style>
+        /* Consider moving to a static CSS file if styles become complex or are reused */
+        .form-container { margin-top: 20px; margin-bottom: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; max-width: 600px; margin-left: auto; margin-right: auto; }
+        .form-container h1 { font-size: 1.8em; margin-bottom: 15px; color: #333; }
+        .form-container p { margin-bottom: 15px; }
+        .form-container .label { font-weight: bold; display: block; margin-bottom: 5px; }
+        .form-container .input { width: 100%; padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
+        .form-container .button { padding: 10px 20px; background-color: #dc3545; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
+        .form-container .button:hover { background-color: #c82333; }
+        .form-container .help.is-danger { color: #dc3545; font-size: 0.9em; margin-top: -5px; margin-bottom: 10px; }
+        .navigation-links { margin-top: 20px; }
+        .navigation-links a { margin-right: 15px; color: #007bff; text-decoration: none; }
+        .navigation-links a:hover { text-decoration: underline; }
+    </style>
+
+    <div class="form-container">
+        <h1>Unassign Asset</h1>
+
+        {% if user_context %}
+            <p>You are about to unassign an asset. The context for redirection after unassignment is user:
+            <strong>{{ user_context.name|default:user_context.username }}</strong> (ID: {{ user_context.id }}).
+            Enter the asset tag of the item you wish to check in (unassign).</p>
+        {% else %}
+            <p>Enter the asset tag of the item you wish to check in (unassign).</p>
+        {% endif %}
+
+        <form method="post" action="{% url 'unassign_asset_by_tag' user_id=user_id %}">
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+                <div class="notification is-danger">
+                    {% for error in form.non_field_errors %}
+                        <p>{{ error }}</p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            <div class="field">
+                <label for="{{ form.asset_tag.id_for_label }}" class="label">{{ form.asset_tag.label }}</label>
+                <div class="control">
+                    {{ form.asset_tag.as_widget(attrs={'class': 'input', 'placeholder': 'Enter asset tag to unassign'}) }}
+                </div>
+                {% if form.asset_tag.help_text %}
+                    <p class="help">{{ form.asset_tag.help_text }}</p>
+                {% endif %}
+                {% for error in form.asset_tag.errors %}
+                    <p class="help is-danger">{{ error }}</p>
+                {% endfor %}
+            </div>
+
+            <button type="submit" class="button">Unassign Asset by Tag</button>
+        </form>
+    </div>
+
+    <div class="navigation-links has-text-centered">
+        {% if user_context and user_context.employee_number %}
+            <a href="{% url 'user_asset_view' %}?employee_number={{ user_context.employee_number }}">Back to {{ user_context.name|default:user_context.username }}'s Assets</a>
+        {% elif user_context %}
+             {# If no employee number, maybe a generic link or just to index #}
+             <a href="{% url 'index' %}">Back to Search</a>
+        {% endif %}
+        <a href="{% url 'index' %}">Back to Home/Search</a>
+    </div>
+
+{% endblock %}

--- a/userCheckIO/urls.py
+++ b/userCheckIO/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path("user_assets/", views.user_asset_view, name="user_asset_view"),
     # URLs for assign/unassign actions
     path("user/<int:user_id>/assign/", views.assign_asset_to_user_view, name="assign_asset"),
-    path("asset/<int:asset_id>/unassign/", views.unassign_asset_from_user_view, name="unassign_asset"),
+    path("asset/<int:asset_id>/unassign/", views.unassign_asset_from_user_view, name="unassign_asset"), # Kept for direct unassignment if still used
+    path('user/<int:user_id>/unassign_by_tag/', views.unassign_asset_by_tag_view, name='unassign_asset_by_tag'),
 ]


### PR DESCRIPTION
This commit modifies the asset management workflow to allow you to input asset tags directly via a text field, rather than selecting from a dropdown list. This is beneficial for workflows involving barcode scanners or direct tag entry.

Changes include:

1.  **Asset Assignment (`assign_asset_to_user_view`):**
    *   Replaced the dropdown list of available assets with a text input field for the asset tag.
    *   The view now fetches asset details (including ID) from Snipe-IT using the provided asset tag before proceeding with the assignment.
    *   Updated `AssignAssetForm` to use `CharField` for `asset_tag`.
    *   Modified `assign_asset.html` template for the new input method.

2.  **Asset De-assignment (Check-in):**
    *   Created a new view `unassign_asset_by_tag_view` that allows unassigning an asset by entering its tag.
    *   This view takes a `user_id` (for context and redirection) and presents a form for asset tag input.
    *   It fetches the asset ID using the tag and then performs the check-in operation via the Snipe-IT API.
    *   Added `UnassignAssetForm` with a `CharField` for `asset_tag`.
    *   Created a new template `unassign_asset_by_tag.html`.
    *   Added a new URL pattern for this view.

3.  **Updated Links:**
    *   Modified the "Unassign" links in `asset_list.html` to point to the new `unassign_asset_by_tag_view`, passing the relevant `user_id`.

4.  **Authentication:**
    *   Ensured that authentication checks are active for both the modified asset assignment view and the new de-assignment view.

These changes streamline the asset handling process for you if you prefer direct tag input, enhancing usability with external input devices like barcode scanners.