### PR TITLE
fix: Improve guidance when no asset categories are found

### DIFF
--- a/userCheckIO/templates/configure_asset_categories.html
+++ b/userCheckIO/templates/configure_asset_categories.html
@@ -41,9 +41,22 @@
                         {{ form.allowed_categories }}
                     </div>
                 </div>
-                {% if form.allowed_categories.help_text %}
+
+                {# Check if the choices list is effectively empty (only contains the placeholder) #}
+                {% if form.allowed_categories.field.choices|length == 1 and form.allowed_categories.field.choices.0.0 == "" %}
+                    <p class="help is-warning" style="margin-top: 10px;">
+                        <strong>No categories available to configure.</strong> This could be due to several reasons:
+                        <ul style="list-style-type: disc; margin-left: 20px; margin-top: 5px;">
+                            <li>There are no categories of type 'asset' defined in your Snipe-IT instance. This application specifically looks for categories suitable for assigning to assets (e.g., hardware, devices).</li>
+                            <li>The API token used by this application may not have permissions to view categories in Snipe-IT.</li>
+                            <li>There might have been an issue connecting to the Snipe-IT API to fetch categories (check for other error messages that may have appeared at the top of the page).</li>
+                        </ul>
+                        Please verify your Snipe-IT setup and the application's environment configuration (API token, URL).
+                    </p>
+                {% elif form.allowed_categories.help_text %}
                     <p class="help">{{ form.allowed_categories.help_text }}</p>
                 {% endif %}
+
                 {% for error in form.allowed_categories.errors %}
                     <p class="help is-danger">{{ error }}</p>
                 {% endfor %}


### PR DESCRIPTION
When configuring asset categories, if no categories of type 'asset' are found in Snipe-IT (or if there are issues fetching them), the administration page previously showed a brief message.

This commit enhances the message in
`userCheckIO/templates/configure_asset_categories.html`. The new message provides a more detailed explanation to you, suggesting potential reasons:
- No categories of type 'asset' in Snipe-IT.
- API token permission issues for viewing categories.
- General API connectivity problems.

This helps you diagnose why categories might not be appearing for selection.