### PR TITLE
fix: Ensure all categories are shown in admin configuration

### DIFF
--- a/userCheckIO/views.py
+++ b/userCheckIO/views.py
@@ -542,7 +542,12 @@ def configure_asset_categories_view(request):
         categories_response = requests.get(categories_url, headers=headers, timeout=10)
         if categories_response.status_code == 200:
             categories_data = categories_response.json().get('rows', [])
-            category_choices_list = [(str(cat['id']), cat['name']) for cat in categories_data if cat.get('category_type') == 'asset']
+            # Removed cat.get('category_type') == 'asset' filter.
+            # Now includes all categories that have an id and a name.
+            category_choices_list = [
+                (str(cat['id']), cat['name']) for cat in categories_data
+                if cat.get('id') is not None and cat.get('name') is not None
+            ]
         else:
             messages.error(request, f"Failed to fetch asset categories from Snipe-IT: Status {categories_response.status_code}")
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Corrects an issue where the 'Configure Asset Categories' admin page would not display any categories if the categories in Snipe-IT did not have their `category_type` field explicitly set to 'asset'.

You reported that categories were visible in other parts of the application (`user_asset_view`) where this strict filter was not applied.

This commit modifies `configure_asset_categories_view` to remove the `category_type == 'asset'` filter when fetching categories for the configuration form. It now includes all categories that have an ID and name, consistent with other views. This allows admins to see and select from all available categories from their Snipe-IT instance for the 'fixed assignment' mode.

The API call still uses `limit=500` and sorting for robustness.