### PR TITLE
feat: Add French language support and navbar language switcher

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-31 22:12+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: simpleSnipeIT/settings.py:36
+msgid "English"
+msgstr ""
+
+#: simpleSnipeIT/settings.py:37
+msgid "French"
+msgstr ""
+
+#: userCheckIO/forms.py:20
+msgid "Enter Your Employee Number"
+msgstr ""
+
+#: userCheckIO/forms.py:24
+msgid "Employee Number"
+msgstr ""
+
+#: userCheckIO/forms.py:51
+msgid "Enter asset tag to assign"
+msgstr ""
+
+#: userCheckIO/forms.py:56
+msgid "Asset Tag to Unassign"
+msgstr ""
+
+#: userCheckIO/forms.py:61
+msgid "Enter asset tag to unassign"
+msgstr ""
+
+#: userCheckIO/forms.py:68
+msgid "Featured Asset Categories"
+msgstr ""
+
+#: userCheckIO/forms.py:69
+msgid ""
+"Select categories to be highlighted in special reports or views. An empty "
+"selection is valid."
+msgstr ""
+
+#: userCheckIO/models.py:6
+msgid "Display category selector"
+msgstr ""
+
+#: userCheckIO/models.py:7
+msgid "Use fixed list of categories"
+msgstr ""
+
+#: userCheckIO/models.py:14
+msgid "Assignment Category Mode"
+msgstr ""
+
+#: userCheckIO/models.py:15
+msgid ""
+"Determines if users select a category during assignment, or if a fixed list "
+"(defined below) is used."
+msgstr ""
+
+#: userCheckIO/models.py:20
+msgid "Allowed Asset Category IDs"
+msgstr ""
+
+#: userCheckIO/models.py:21
+msgid ""
+"List of Snipe-IT category IDs. Used when mode is 'fixed'. The asset's actual "
+"category must be in this list."
+msgstr ""
+
+#: userCheckIO/models.py:25
+msgid "Asset Category Configuration"
+msgstr ""
+
+#: userCheckIO/models.py:26
+msgid "Asset Category Configurations"
+msgstr ""
+
+#: userCheckIO/templates/base.html:38
+msgid "Home"
+msgstr "Accueil"

--- a/simpleSnipeIT/settings.py
+++ b/simpleSnipeIT/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 import os, environ
 from pathlib import Path
+from django.utils.translation import gettext_lazy
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -30,6 +31,11 @@ environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-m9*aie%8j&=7yykp7n40vd5@na_mika3sq&9n(j)5vz((h%c$z'
 #SECRET_KEY = env('SECRET_KEY')
+
+LANGUAGES = [
+    ('en', gettext_lazy('English')),
+    ('fr', gettext_lazy('French')),
+]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env('DJANGO_DEBUG')
@@ -53,6 +59,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -120,6 +127,10 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 
 USE_TZ = True
+
+LOCALE_PATHS = [
+    BASE_DIR / 'locale',
+]
 
 
 # Static files (CSS, JavaScript, Images)

--- a/simpleSnipeIT/urls.py
+++ b/simpleSnipeIT/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include # Corrected import
 urlpatterns = [
     path("", include("userCheckIO.urls")), # Corrected path
     path('admin/', admin.site.urls),
+    path('i18n/', include('django.conf.urls.i18n')),
 ]

--- a/userCheckIO/templates/base.html
+++ b/userCheckIO/templates/base.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -34,7 +35,7 @@
         <div id="navbarBasic" class="navbar-menu">
             <div class="navbar-start">
                 <a href="{% url 'index' %}" class="navbar-item">
-                    Home
+                    {% trans "Home" %}
                 </a>
                 {% if request.session.is_admin %}
                 <a href="{% url 'configure_asset_categories' %}" class="navbar-item">
@@ -51,6 +52,22 @@
                 {% endif %}
             </div>
             <div class="navbar-end">
+                <form action="{% url 'set_language' %}" method="post" class="navbar-item">
+                    {% csrf_token %}
+                    <input name="next" type="hidden" value="{{ request.get_full_path|slice:":-3" }}">
+                    <div class="select">
+                        <select name="language" onchange="this.form.submit()">
+                            {% get_current_language as LANGUAGE_CODE %}
+                            {% get_available_languages as LANGUAGES %}
+                            {% get_language_info_list for LANGUAGES as languages %}
+                            {% for language in languages %}
+                                <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
+                                    {{ language.name_local }} ({{ language.code }})
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </form>
                 {% if request.session.is_admin %}
                 <a href="{% url 'logout' %}" class="navbar-item">
                     Logout


### PR DESCRIPTION
This commit introduces internationalization support for the French language.

Key changes:
- Configured Django's i18n settings for French ('fr').
- Added `LANGUAGES` and `LOCALE_PATHS` to settings.py.
- Created locale directory structure and initial French translation files (`django.po`, `django.mo`).
- Added a sample translation for "Home" to "Accueil".
- Integrated a language switcher dropdown into the main navbar in `base.html`.
- Added URL patterns for Django's `set_language` view to handle language changes.
- Ensured `LocaleMiddleware` is active.

You can now switch between English and French using the dropdown in the navbar. The "Home" link in the navbar is translated as an example. Further translations will be needed for full site localization.